### PR TITLE
Use non-actions token for release-candidate

### DIFF
--- a/root/.github/workflows/release-candidate.yml
+++ b/root/.github/workflows/release-candidate.yml
@@ -29,4 +29,4 @@ jobs:
           pr_title: Release ${{ steps.create_release.outputs.version}}
           pr_body: close \#${{ github.event.issue.number }}
           pr_assignee: ${{ github.actor }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
to trigger CI on release-candidate PR.